### PR TITLE
feat(devtools): redesign panel layout + recorder, fix iframe/idle bugs

### DIFF
--- a/background.js
+++ b/background.js
@@ -73,21 +73,32 @@ export const initializeServiceWorker = () => {
   // Add this helper function for script injection
   async function injectScripts(tabId) {
     try {
+      // Inject into every frame (not just the top document) so locator mode
+      // works inside iframes too. Content scripts also auto-inject via the
+      // manifest (all_frames); this executeScript path is the activation-time
+      // fallback for frames that loaded before the extension/devtools did.
+      const target = { tabId, allFrames: true };
+
       // First inject helper
       await chrome.scripting.executeScript({
-        target: { tabId },
+        target,
         files: ['locator_helper.js']
       });
 
-      // Then inject generator
+      // Then inject generator + v2 engine (mirror the manifest's idle bundle)
       await chrome.scripting.executeScript({
-        target: { tabId },
+        target,
         files: ['locator_generator.js']
+      });
+
+      await chrome.scripting.executeScript({
+        target,
+        files: ['locator_engine_v2.js']
       });
 
       // Finally inject content script
       await chrome.scripting.executeScript({
-        target: { tabId },
+        target,
         files: ['content.js']
       });
 

--- a/devtools/panel.css
+++ b/devtools/panel.css
@@ -127,19 +127,22 @@ body::before {
 
 .container {
   height: 100vh;
-  padding: 8px 16px 12px 16px;
+  padding: 6px 14px 8px 14px;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 6px;
   overflow: hidden;
 }
 
 /* -------- Header --------------------------------------------------------*/
+/* Slim, single-line identity bar. In bottom-dock the panel is wide but
+   short, so the wordmark is kept compact to give the vertical budget to
+   locator content rather than branding. */
 .header {
   display: flex;
-  align-items: baseline;
+  align-items: center;
   justify-content: space-between;
-  padding: 2px 4px 6px 4px;
+  padding: 1px 2px 4px 2px;
   border-bottom: 1px solid var(--hairline);
   background: transparent;
   color: var(--ink-1);
@@ -149,13 +152,14 @@ body::before {
 
 .logo-title {
   display: flex;
-  align-items: baseline;
-  gap: 10px;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
 }
 
 .logo {
-  width: 22px;
-  height: 22px;
+  width: 18px;
+  height: 18px;
   align-self: center;
   filter: var(--logo-filter, none);
   opacity: 0.92;
@@ -165,7 +169,7 @@ body::before {
   margin: 0;
   font-family: var(--font-display);
   font-weight: 400;
-  font-size: 26px;
+  font-size: 19px;
   line-height: 1;
   letter-spacing: -0.01em;
   color: var(--ink-1);
@@ -176,7 +180,7 @@ body::before {
 .brand-script {
   font-style: italic;
   font-family: var(--font-display);
-  font-size: 28px;
+  font-size: 20px;
   letter-spacing: -0.02em;
 }
 
@@ -251,7 +255,11 @@ body::before {
   box-shadow: var(--shadow-pop);
   z-index: 100;
   padding: 6px;
-  overflow: hidden;
+  /* Many items + a short bottom-dock panel = the menu used to clip. Cap its
+     height to the viewport and let it scroll, like the side drawers. */
+  max-height: calc(100vh - 48px);
+  overflow-y: auto;
+  overscroll-behavior: contain;
 }
 
 .dropdown-content.show {
@@ -329,9 +337,9 @@ body::before {
 /* -------- Toolbar / controls --------------------------------------------*/
 .controls {
   display: flex;
-  gap: 8px;
+  gap: 6px;
   align-items: center;
-  padding: 8px 10px;
+  padding: 6px 10px;
   border-radius: var(--radius);
   background: var(--surface);
   border: 1px solid var(--hairline);
@@ -344,8 +352,8 @@ body::before {
   content: "";
   position: absolute;
   left: 0;
-  top: 8px;
-  bottom: 8px;
+  top: 6px;
+  bottom: 6px;
   width: 2px;
   background: var(--accent);
   border-radius: 2px 0 0 2px;
@@ -620,45 +628,51 @@ body.dark-mode .engine-select {
   position: relative;
 }
 
+/* Compact single-row header. The panel is short in bottom-dock, so the
+   title, status line and section actions share one slim row instead of a
+   poster-sized two-line block — buying ~30px back for the results grid. */
 .section-header {
-  padding: 14px 18px 12px 18px;
+  padding: 7px 12px 7px 14px;
   border-bottom: 1px solid var(--hairline);
   display: flex;
-  justify-content: space-between;
-  align-items: flex-end;
+  flex-direction: row;
+  align-items: center;
   gap: 12px;
-  background:
-    linear-gradient(180deg, var(--surface) 0%, var(--surface) 70%, transparent 100%);
+  background: var(--surface);
 }
 
 .section-title {
   display: flex;
-  flex-direction: column;
-  gap: 4px;
-  min-width: 0;
+  flex-direction: row;
+  align-items: baseline;
+  gap: 10px;
+  flex: 0 0 auto;
 }
 
 .section h3 {
   margin: 0;
-  font-family: var(--font-display);
-  font-style: italic;
-  font-weight: 400;
-  font-size: 22px;
-  line-height: 1;
+  font-family: var(--font-sans);
+  font-style: normal;
+  font-weight: 600;
+  font-size: 13px;
+  line-height: 1.2;
   color: var(--ink-1);
-  letter-spacing: -0.01em;
+  letter-spacing: 0.01em;
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .section-subtitle {
   margin: 0;
   font-family: var(--font-mono);
-  font-size: 10.5px;
-  letter-spacing: 0.05em;
+  font-size: 10px;
+  letter-spacing: 0.04em;
   color: var(--ink-3);
   text-transform: uppercase;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  min-width: 0;
 }
 
 .section-actions {
@@ -1368,16 +1382,26 @@ body.dark-mode .validate-btn:hover {
 }
 
 /* -------- Empty state placeholder ---------------------------------------*/
+/* When the results list holds only this placeholder, center it in the
+   available space instead of letting its min-height force a scroll. */
+#locatorResults:has(.placeholder) {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
 .placeholder {
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   gap: 14px;
-  padding: 56px 20px;
+  padding: 24px 20px;
   text-align: center;
   color: var(--ink-3);
-  min-height: 240px;
+  min-height: 0;
   position: relative;
 }
 
@@ -1927,7 +1951,6 @@ body.dark-mode .primary-btn:hover {
    banners (which all advertise locator-side features). The recorder
    section has its own "Back to Locators" button at the top to come back. */
 body.view-recorder .controls,
-body.view-recorder #topBanners,
 body.view-recorder #feedbackRatingContainer { display: none !important; }
 
 /* Recorder toolbar: a single compact row of identification (Back + title +
@@ -1947,7 +1970,7 @@ body.view-recorder #feedbackRatingContainer { display: none !important; }
   align-items: center;
   gap: 6px;
   flex-wrap: wrap;
-  margin-bottom: 6px;
+  margin-bottom: 10px;
 }
 .rec-flex-spacer { flex: 1 1 auto; }
 
@@ -2059,6 +2082,7 @@ body.view-recorder #feedbackRatingContainer { display: none !important; }
 
 /* "✨ AI" badge + generated test name shown in the code-pane title once an
    AI generation is the active output. */
+.rec-ai-badge[hidden] { display: none !important; }
 .rec-ai-badge {
   display: inline-block;
   margin-left: 6px;
@@ -2110,18 +2134,61 @@ body.view-recorder #feedbackRatingContainer { display: none !important; }
 .ai-caveat {
   display: flex;
   flex-wrap: wrap;
-  align-items: baseline;
+  align-items: center;
   gap: 6px;
   margin: 6px 0 8px 0;
-  padding: 6px 10px;
-  border-radius: 8px;
+  padding: 4px 6px 4px 10px;
+  border-radius: 7px;
   background: var(--bg-subtle, rgba(127, 127, 127, 0.07));
   border: 1px solid var(--hairline);
-  font-size: 11px;
-  line-height: 1.4;
+  font-size: 10.5px;
+  line-height: 1.35;
   color: var(--ink-3);
 }
 .ai-caveat-text { flex: 1 1 220px; }
+/* Locator-view caveat lives inline inside the "Element Locators" header bar,
+   always visible (no dismiss) and on a single line. It grows to fill the
+   space between the title and the actions; if the panel is too narrow the
+   text elides rather than wrapping to a new line. */
+#locAiCaveat {
+  flex: 0 1 auto;
+  min-width: 0;
+  margin: 0 0 0 auto;
+  padding: 0;
+  background: none;
+  border: none;
+  border-radius: 0;
+  flex-wrap: nowrap;
+}
+#locAiCaveat .ai-caveat-text {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+/* Recorder caveat: a slim single line inline in the toolbar, sitting right
+   after the credits pill. Shrinks and elides instead of wrapping. */
+#recAiCaveat {
+  flex: 0 1 auto;
+  min-width: 0;
+  margin: 0;
+  padding: 0;
+  background: none;
+  border: none;
+  border-radius: 0;
+  flex-wrap: nowrap;
+}
+#recAiCaveat .ai-caveat-text {
+  flex: 0 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+/* The credits pill's display:inline-block was overriding the `hidden`
+   attribute, leaving an empty gradient bar when there are no credits. */
+.ai-caveat-credits[hidden] { display: none !important; }
 .ai-caveat-link {
   color: #7c6df2;
   font-weight: 600;
@@ -2208,11 +2275,16 @@ body.dark-mode .rec-framework-select {
 
 .rec-body {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(0, 1.2fr);
+  /* Code section gets the lion's share of the width; steps stays a slim
+     reference column. */
+  grid-template-columns: minmax(0, 0.7fr) minmax(0, 1.8fr);
   gap: 12px;
   flex: 1 1 auto;
   min-height: 0;
 }
+
+/* Credits pill sits inline next to the title in the toolbar. */
+.rec-credits { align-self: center; }
 .rec-steps-pane,
 .rec-code-pane {
   display: flex;
@@ -2248,6 +2320,9 @@ body.dark-mode .rec-framework-select {
   overflow-y: auto;
   flex: 1 1 auto;
 }
+/* When there are no steps, collapse the empty list so the "No steps yet"
+   placeholder (flex:1) fills the whole pane and centers in it. */
+.rec-steps-list:empty { flex: 0 0 auto; }
 .rec-steps-list li {
   display: grid;
   grid-template-columns: 22px 70px minmax(0, 1fr);
@@ -2328,25 +2403,6 @@ body.dark-mode .rec-framework-select {
   .rec-body { grid-template-columns: minmax(0, 1fr); }
 }
 
-/* "What's new" variant of .update-alert. Same skeleton, calmer gradient and a
-   non-rotating sparkle so it's visually distinguishable from the version
-   "Update available" banner if both ever appear at once. */
-.new-feature-alert {
-  background: linear-gradient(135deg, #1d2540, #2a1f5a);
-}
-.new-feature-alert .update-content svg {
-  animation: none;
-  color: #ffd569;
-  filter: drop-shadow(0 0 4px rgba(255, 213, 105, 0.55));
-}
-.new-feature-alert .update-content em {
-  font-style: normal;
-  font-family: var(--font-mono);
-  font-size: 11px;
-  padding: 1px 6px;
-  border-radius: 4px;
-  background: rgba(255, 255, 255, 0.10);
-}
 
 .update-content {
   display: flex;
@@ -2425,22 +2481,40 @@ body.dark-mode .rec-framework-select {
 .dock-warning svg { flex-shrink: 0; }
 
 /* -------- Feedback rating ----------------------------------------------*/
-/* Compact, centered pill — sits unobtrusively in the toolbar slot rather
- * than spanning the full panel width. Toggled via JS by setting
- * `display: none` to hide and clearing the inline style to show, so the
- * stylesheet's `display: flex` is what governs the visible state. */
+/* Centered prompt over a blurred full-panel backdrop. The container is the
+ * backdrop (covers everything, blurs the UI behind it); the inner card is the
+ * pill. Toggled via JS by setting `display: none` to hide and clearing the
+ * inline style to show, so the stylesheet's `display: flex` governs. */
 .feedback-rating-container {
+  position: fixed;
+  inset: 0;
+  z-index: 9990;
   display: flex;
   align-items: center;
   justify-content: center;
+  padding: 16px;
+  background: rgba(14, 16, 20, 0.5);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+  animation: modalFade 0.18s cubic-bezier(0.2, 0.7, 0.2, 1);
+}
+
+.feedback-rating-card {
+  display: flex;
+  align-items: center;
   gap: 12px;
-  width: max-content;
   max-width: 100%;
-  margin: 8px auto;
-  padding: 6px 10px 6px 14px;
+  padding: 12px 14px 12px 20px;
   background: var(--surface);
-  border: 1px solid var(--hairline);
+  border: 1px solid var(--hairline-strong);
   border-radius: 999px;
+  box-shadow: var(--shadow-pop);
+  animation: feedbackPop 0.28s cubic-bezier(0.2, 0.7, 0.2, 1);
+}
+
+@keyframes feedbackPop {
+  from { opacity: 0; transform: translateY(10px) scale(0.97); }
+  to   { opacity: 1; transform: none; }
 }
 
 .feedback-rating-container p {
@@ -2653,19 +2727,304 @@ body.dark-mode .rec-framework-select {
 
 .ai-link svg { width: 13px; height: 13px; }
 
+/* Optimize-with-AI promoted into the toolbar: match the 32px button row. */
+.controls #optimizeAiBtn { height: 32px; flex-shrink: 0; }
+
+/* -------- Settings: toolbar gear button --------------------------------*/
+.icon-btn-square {
+  padding: 0;
+  width: 32px;
+  height: 32px;
+  flex-shrink: 0;
+  justify-content: center;
+}
+.icon-btn-square svg { opacity: 0.8; }
+.icon-btn-square:hover svg { opacity: 1; color: var(--accent-deep); }
+body.dark-mode .icon-btn-square:hover svg { color: var(--accent); }
+
+/* -------- Settings drawer ----------------------------------------------*/
+/* Slides in from the right over a dimmed overlay. Houses the validation
+   toggles, engine/copy selectors and the AI provider form that used to
+   crowd the toolbar. position:fixed escapes the .container overflow clip. */
+.settings-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(14, 16, 20, 0.42);
+  backdrop-filter: blur(3px);
+  -webkit-backdrop-filter: blur(3px);
+  z-index: 9998;
+  animation: modalFade 0.18s cubic-bezier(0.2, 0.7, 0.2, 1);
+}
+.settings-overlay[hidden] { display: none; }
+
+.settings-drawer {
+  position: fixed;
+  top: 0;
+  right: 0;
+  height: 100vh;
+  width: 380px;
+  max-width: 92vw;
+  background: var(--surface);
+  border-left: 1px solid var(--hairline);
+  box-shadow: -18px 0 50px rgba(0, 0, 0, 0.22);
+  z-index: 9999;
+  display: flex;
+  flex-direction: column;
+  transform: translateX(100%);
+  transition: transform 0.26s cubic-bezier(0.2, 0.7, 0.2, 1);
+  will-change: transform;
+}
+.settings-drawer.open { transform: none; }
+
+.settings-drawer-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 16px 13px 20px;
+  border-bottom: 1px solid var(--hairline);
+  flex-shrink: 0;
+}
+.settings-drawer-header h3 {
+  margin: 0;
+  font-family: var(--font-display);
+  font-style: italic;
+  font-weight: 400;
+  font-size: 22px;
+  line-height: 1.1;
+  letter-spacing: -0.01em;
+  color: var(--ink-1);
+}
+
+.settings-drawer-body {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  padding: 4px 20px 24px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.settings-section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding-top: 16px;
+  border-top: 1px solid var(--hairline);
+}
+.settings-section:first-child { border-top: none; padding-top: 10px; }
+
+.settings-section-label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--ink-3);
+}
+
+/* Toggle row: descriptive text on the left, switch on the right. */
+.settings-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  cursor: pointer;
+  user-select: none;
+}
+.settings-row-text { display: flex; flex-direction: column; gap: 3px; min-width: 0; }
+.settings-row-title { font-size: 13px; font-weight: 600; color: var(--ink-1); }
+.settings-row-sub { font-size: 11.5px; line-height: 1.4; color: var(--ink-3); }
+
+.settings-toggle { position: relative; display: inline-flex; flex-shrink: 0; }
+.settings-toggle input[type="checkbox"] {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  pointer-events: none;
+}
+.settings-toggle input[type="checkbox"]:checked ~ .toggle-track { background: var(--accent); }
+.settings-toggle input[type="checkbox"]:checked ~ .toggle-track::after {
+  transform: translateX(12px);
+  background: var(--ink-inverse);
+}
+.settings-toggle input[type="checkbox"]:focus-visible ~ .toggle-track {
+  box-shadow: 0 0 0 3px var(--hairline-glow);
+}
+
+.settings-save-btn { align-self: flex-start; margin-top: 4px; }
+
+/* -------- Notification bell + badge ------------------------------------*/
+#notificationsBtn { position: relative; }
+.notif-badge {
+  position: absolute;
+  top: 3px;
+  right: 3px;
+  min-width: 8px;
+  height: 8px;
+  padding: 0 3px;
+  border-radius: 999px;
+  background: var(--bad);
+  border: 1.5px solid var(--bg);
+  box-sizing: content-box;
+}
+.notif-badge[hidden] { display: none; }
+
+/* -------- Generic side drawer (shared shell for notifications) ---------*/
+.side-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(14, 16, 20, 0.42);
+  backdrop-filter: blur(3px);
+  -webkit-backdrop-filter: blur(3px);
+  z-index: 9998;
+  animation: modalFade 0.18s cubic-bezier(0.2, 0.7, 0.2, 1);
+}
+.side-overlay[hidden] { display: none; }
+
+.side-drawer {
+  position: fixed;
+  top: 0;
+  right: 0;
+  height: 100vh;
+  width: 380px;
+  max-width: 92vw;
+  background: var(--surface);
+  border-left: 1px solid var(--hairline);
+  box-shadow: -18px 0 50px rgba(0, 0, 0, 0.22);
+  z-index: 9999;
+  display: flex;
+  flex-direction: column;
+  transform: translateX(100%);
+  transition: transform 0.26s cubic-bezier(0.2, 0.7, 0.2, 1);
+  will-change: transform;
+}
+.side-drawer.open { transform: none; }
+
+.side-drawer-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 16px 13px 20px;
+  border-bottom: 1px solid var(--hairline);
+  flex-shrink: 0;
+}
+.side-drawer-header h3 {
+  margin: 0;
+  font-family: var(--font-display);
+  font-style: italic;
+  font-weight: 400;
+  font-size: 22px;
+  line-height: 1.1;
+  letter-spacing: -0.01em;
+  color: var(--ink-1);
+}
+.side-drawer-body {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  padding: 14px 20px 24px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+/* -------- Notification items (flat info cards, not alert banners) ------*/
+.notif-empty {
+  font-size: 12.5px;
+  line-height: 1.5;
+  color: var(--ink-3);
+  padding: 8px 2px;
+}
+
+/* Neutralise the old banner chrome so these read as calm info cards. */
+.notif-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  margin: 0;
+  padding: 14px;
+  border-radius: var(--radius);
+  background: var(--surface-2);
+  border: 1px solid var(--hairline);
+  box-shadow: none;
+  animation: none;
+  color: var(--ink-1);
+  overflow: visible;
+}
+.notif-item::before { display: none !important; }
+.notif-item[hidden],
+.notif-item.hidden { display: none !important; }
+/* The credits item keeps its #aiCreditsBanner id (JS sets data-state on it),
+   but inside the drawer it must stay a calm flat card — override the colored
+   per-state banner backgrounds that would otherwise win on specificity. */
+.notif-item.ai-credits-banner,
+.notif-item.ai-credits-banner[data-state] {
+  background: var(--surface-2);
+  color: var(--ink-1);
+  border-color: var(--hairline);
+}
+
+.notif-item-icon {
+  flex-shrink: 0;
+  width: 30px;
+  height: 30px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  background: var(--accent-soft);
+  color: var(--accent-deep);
+  margin: 0;
+  inset: auto;
+  position: static;
+}
+body.dark-mode .notif-item-icon { color: var(--accent); }
+
+.notif-item-body {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 8px;
+  min-width: 0;
+  flex: 1 1 auto;
+}
+.notif-item-text { font-size: 13px; font-weight: 500; color: var(--ink-1); }
+.notif-item .ai-credits-banner-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--ink-1);
+}
+.notif-item .ai-credits-banner-sub {
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--ink-3);
+}
+.notif-item .ai-credits-banner-sub b { color: var(--ink-2); font-weight: 600; }
+/* Hide the credit dot meter in the notification card (JS still updates it
+   harmlessly off-screen — removing the node would break panelBannerMeter). */
+.notif-item .ai-credits-banner-meter { display: none !important; }
+.notif-item-cta {
+  align-self: flex-start;
+  margin-top: 2px;
+  height: auto;
+  white-space: nowrap;
+}
+
 /* -------- Responsive ----------------------------------------------------*/
 @media (max-width: 640px) {
-  .container { padding: 12px; gap: 10px; }
+  /* Narrow == side-dock (tall + skinny). Vertical budget is just as tight
+     here, so keep the compacted spacing rather than re-inflating it. */
+  .container { padding: 6px 10px 8px 10px; gap: 6px; }
 
-  .header { padding-bottom: 10px; }
-  .header h1 { font-size: 22px; }
-  .brand-script { font-size: 24px; }
+  .header { padding-bottom: 4px; }
+  .header h1 { font-size: 19px; }
+  .brand-script { font-size: 20px; }
   .badge { display: none; }
 
   .controls {
     flex-wrap: wrap;
     gap: 6px;
-    padding: 8px;
+    padding: 6px 8px;
   }
 
   .search-box { order: -1; flex: 1 1 100%; max-width: none; }
@@ -2693,11 +3052,11 @@ body.dark-mode .rec-framework-select {
   .locators-table .locator-item:first-child { padding-left: 14px; }
 
   .section-header {
-    flex-wrap: wrap;
-    gap: 10px;
+    flex-wrap: nowrap;
+    gap: 8px;
   }
 
-  .section h3 { font-size: 18px; }
+  .section h3 { font-size: 13px; }
 
   .action-btn span { display: none; }
   .action-btn.ai-btn span { display: inline; }

--- a/devtools/panel.html
+++ b/devtools/panel.html
@@ -37,6 +37,13 @@
           </svg>
         </button>
 
+        <button id="notificationsBtn" class="icon-btn" title="Notifications" aria-label="Notifications">
+          <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"></path>
+            <path d="M13.73 21a2 2 0 0 1-3.46 0"></path>
+          </svg>
+          <span id="notifBadge" class="notif-badge" hidden></span>
+        </button>
 
         <div class="dropdown">
           <button id="menuBtn" class="icon-btn" title="Menu">
@@ -119,89 +126,71 @@
       </div>
     </div>
     
-    <!-- Single banner section. Each banner inside is gated by its own
-         eligibility check (version mismatch, available AI credits, copy
-         format = raw); none are user-dismissable, so users always see what
-         is currently relevant and nothing more. -->
-    <div id="topBanners" class="banner-stack">
-      <div id="updateAlertDev" class="update-alert hidden">
-        <div class="update-content">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-            <path d="M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83"/>
-          </svg>
-          <span>Update available!</span>
-          <button id="updateNowBtnDev" class="update-btn">Update Now</button>
-        </div>
-        <button id="closeUpdateAlertDev" class="close-alert" aria-label="Dismiss">&times;</button>
+    <!-- Notifications drawer. The old inline update / AI-credit banners now
+         live here as information items instead of pushing the panel content
+         down. The bell in the header opens this drawer; each item keeps its
+         original id so the existing eligibility logic just updates its data
+         in place — items are never user-removable. -->
+    <div id="notificationsOverlay" class="side-overlay" hidden></div>
+    <aside id="notificationsDrawer" class="side-drawer" aria-hidden="true" aria-label="Notifications">
+      <div class="side-drawer-header">
+        <h3>Notifications</h3>
+        <button id="closeNotificationsBtn" class="close-btn" aria-label="Close notifications">&times;</button>
       </div>
+      <div class="side-drawer-body notif-body">
+        <p id="notifEmpty" class="notif-empty">You're all caught up — no notifications right now.</p>
 
-      <div id="newFeatureBanner" class="update-alert new-feature-alert hidden">
-        <div class="update-content">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="none" stroke-linejoin="round">
-            <path d="M12 3 L13.7 9.3 L20 11 L13.7 12.7 L12 19 L10.3 12.7 L4 11 L10.3 9.3 Z" fill="currentColor"/>
-          </svg>
-          <span><strong>New:</strong>&nbsp;<em>Intelligent&nbsp;Recorder</em> captures clicks, typing &amp; scrolls and generates AI-powered Selenium / Playwright / Cypress / WebdriverIO tests. <em>Copy&nbsp;as</em> does the same for single locators.</span>
-        </div>
-      </div>
-
-      <div id="aiCreditsBanner" class="ai-credits-banner" hidden>
-        <span class="ai-credits-shimmer" aria-hidden="true"></span>
-        <span class="ai-credits-spark ai-credits-spark--1" aria-hidden="true">
-          <svg viewBox="0 0 24 24" width="10" height="10" fill="currentColor">
-            <path d="M12 2 L13.6 9.4 L21 11 L13.6 12.6 L12 20 L10.4 12.6 L3 11 L10.4 9.4 Z"/>
-          </svg>
-        </span>
-        <span class="ai-credits-spark ai-credits-spark--2" aria-hidden="true">
-          <svg viewBox="0 0 24 24" width="8" height="8" fill="currentColor">
-            <path d="M12 2 L13.6 9.4 L21 11 L13.6 12.6 L12 20 L10.4 12.6 L3 11 L10.4 9.4 Z"/>
-          </svg>
-        </span>
-        <span class="ai-credits-spark ai-credits-spark--3" aria-hidden="true">
-          <svg viewBox="0 0 24 24" width="6" height="6" fill="currentColor">
-            <path d="M12 2 L13.6 9.4 L21 11 L13.6 12.6 L12 20 L10.4 12.6 L3 11 L10.4 9.4 Z"/>
-          </svg>
-        </span>
-        <div class="ai-credits-banner-icon" aria-hidden="true">
-          <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-            <path d="M12 3 L13.7 9.3 L20 11 L13.7 12.7 L12 19 L10.3 12.7 L4 11 L10.3 9.3 Z" fill="currentColor" stroke="none"/>
-            <path d="M19 4 L19.7 6.3 L22 7 L19.7 7.7 L19 10 L18.3 7.7 L16 7 L18.3 6.3 Z" fill="currentColor" stroke="none" opacity="0.85"/>
-            <path d="M5 16 L5.6 17.7 L7.3 18.3 L5.6 18.9 L5 20.6 L4.4 18.9 L2.7 18.3 L4.4 17.7 Z" fill="currentColor" stroke="none" opacity="0.7"/>
-          </svg>
-        </div>
-        <div class="ai-credits-banner-body">
-          <div class="ai-credits-banner-title" id="aiCreditsBannerTitle">3 free AI optimizations on us</div>
-          <div class="ai-credits-banner-sub" id="aiCreditsBannerSub">
-            Click <b>Optimize with AI</b> on any element — no setup, no API key needed.
+        <div id="updateAlertDev" class="notif-item update-alert hidden">
+          <div class="notif-item-icon" aria-hidden="true">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M21 2v6h-6"></path>
+              <path d="M3 12a9 9 0 0 1 15-6.7L21 8"></path>
+              <path d="M3 22v-6h6"></path>
+              <path d="M21 12a9 9 0 0 1-15 6.7L3 16"></path>
+            </svg>
+          </div>
+          <div class="notif-item-body">
+            <span class="notif-item-text">Update available!</span>
+            <button id="updateNowBtnDev" class="btn primary-btn notif-item-cta">Update Now</button>
           </div>
         </div>
-        <div class="ai-credits-banner-meter" id="aiCreditsBannerMeter" aria-hidden="true">
-          <span class="ai-credit-dot" data-i="1"></span>
-          <span class="ai-credit-dot" data-i="2"></span>
-          <span class="ai-credit-dot" data-i="3"></span>
-        </div>
-        <div class="ai-credits-banner-actions">
-          <button id="aiCreditsBannerCta" class="btn ai-credits-cta" type="button">
-            <svg viewBox="0 0 24 24" width="12" height="12" fill="currentColor" aria-hidden="true">
-              <path d="M12 2 L13.6 9.4 L21 11 L13.6 12.6 L12 20 L10.4 12.6 L3 11 L10.4 9.4 Z"/>
+
+        <div id="aiCreditsBanner" class="notif-item ai-credits-banner" hidden>
+          <div class="notif-item-icon ai-credits-banner-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M12 3 L13.7 9.3 L20 11 L13.7 12.7 L12 19 L10.3 12.7 L4 11 L10.3 9.3 Z" fill="currentColor" stroke="none"/>
             </svg>
-            <span>Add your API key</span>
-          </button>
-          <button id="aiCreditsBannerDismiss" class="ai-credits-banner-close" type="button" aria-label="Dismiss">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round">
-              <line x1="18" y1="6" x2="6" y2="18"></line>
-              <line x1="6" y1="6" x2="18" y2="18"></line>
-            </svg>
-          </button>
+          </div>
+          <div class="notif-item-body ai-credits-banner-body">
+            <div class="ai-credits-banner-title" id="aiCreditsBannerTitle">3 free AI optimizations on us</div>
+            <div class="ai-credits-banner-sub" id="aiCreditsBannerSub">
+              Click <b>Optimize with AI</b> on any element — no setup, no API key needed.
+            </div>
+            <div class="ai-credits-banner-meter" id="aiCreditsBannerMeter" aria-hidden="true">
+              <span class="ai-credit-dot" data-i="1"></span>
+              <span class="ai-credit-dot" data-i="2"></span>
+              <span class="ai-credit-dot" data-i="3"></span>
+            </div>
+            <button id="aiCreditsBannerCta" class="btn ai-credits-cta notif-item-cta" type="button">
+              <svg viewBox="0 0 24 24" width="12" height="12" fill="currentColor" aria-hidden="true">
+                <path d="M12 2 L13.6 9.4 L21 11 L13.6 12.6 L12 20 L10.4 12.6 L3 11 L10.4 9.4 Z"/>
+              </svg>
+              <span>Add your API key</span>
+            </button>
+          </div>
         </div>
       </div>
-    </div>
+    </aside>
 
-    <!-- Feedback Rating Container (Inline) -->
+    <!-- Feedback rating prompt. A centered card over a blurred full-panel
+         backdrop — the container is the backdrop, the inner card is the pill. -->
     <div id="feedbackRatingContainer" class="feedback-rating-container" style="display: none;">
-      <p>How do you like Locator Spy?</p>
-      <div class="rating-buttons">
-        <button id="thumbsUp" class="rating-btn" title="I love it!">👍</button>
-        <button id="thumbsDown" class="rating-btn" title="Needs improvement">👎</button>
+      <div class="feedback-rating-card">
+        <p>How do you like Locator Spy?</p>
+        <div class="rating-buttons">
+          <button id="thumbsUp" class="rating-btn" title="I love it!">👍</button>
+          <button id="thumbsDown" class="rating-btn" title="Needs improvement">👎</button>
+        </div>
       </div>
     </div>
 
@@ -253,179 +242,83 @@
         </svg>
         <input type="text" placeholder="Filter locators...">
       </div>
-      <label class="toggle-container">
-        <input type="checkbox" id="autoValidatorToggle">
-        <span class="toggle-track" aria-hidden="true"></span>
-        <span class="toggle-label">Auto&nbsp;Validate</span>
-      </label>
-      <label class="toggle-container">
-        <input type="checkbox" id="autoOptimizeToggle">
-        <span class="toggle-track" aria-hidden="true"></span>
-        <span class="toggle-label">Auto&nbsp;Optimize</span>
-      </label>
-      <label class="toggle-container engine-select-wrap" title="Locator generation engine">
-        <span class="toggle-label engine-select-label">Engine</span>
-        <select id="engineSelect" class="engine-select">
-          <option value="v2">v2 · anchor-first</option>
-          <option value="v1">v1 · legacy</option>
-        </select>
-      </label>
-      <label class="toggle-container engine-select-wrap" title="Copy format — wraps each locator in framework code on copy">
-        <span class="toggle-label engine-select-label">Copy as</span>
-        <select id="copyFormatSelect" class="engine-select">
-          <option value="raw">Raw</option>
-          <option value="selenium-java">Selenium Java</option>
-          <option value="selenium-python">Selenium Python</option>
-          <option value="playwright">Playwright</option>
-          <option value="cypress">Cypress</option>
-          <option value="webdriverio">WebdriverIO</option>
-        </select>
-      </label>
+      <button id="optimizeAiBtn" class="action-btn ai-btn" title="Optimize using AI">
+        <img src="../images/ai2.png" width="14" height="14" alt="">
+        <span>Optimize&nbsp;with&nbsp;AI</span>
+        <span id="aiCreditsBadge" class="credits-badge" hidden></span>
+      </button>
+      <button id="openSettingsBtn" class="btn icon-btn-square" title="Settings — validation, engine, copy format & AI" aria-label="Open settings">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <circle cx="12" cy="12" r="3"></circle>
+          <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09a1.65 1.65 0 0 0 1.51-1 1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33h.05a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51h.05a1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82v.05a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"></path>
+        </svg>
+      </button>
     </div>
 
-    <div class="results">
-      <div class="section locator-view" id="locatorView">
-        <div class="section-header">
-          <div class="section-title">
-            <h3 id="locatorSectionTitle">Element Locators</h3>
-            <p id="locatorSectionSubtitle" class="section-subtitle">
-              Activate locator mode and hover on the page
-            </p>
-          </div>
-          <div class="section-actions">
-            <button class="action-btn icon-only" title="Copy All">
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
-                <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
-              </svg>
-            </button>
-            <button id="optimizeAiBtn" class="action-btn ai-btn" title="Optimize using AI">
-              <img src="../images/ai2.png" width="14" height="14" alt="">
-              <span>Optimize&nbsp;with&nbsp;AI</span>
-              <span id="aiCreditsBadge" class="credits-badge" hidden></span>
-            </button>
-            <button id="aiSettingsBtn" class="action-btn ghost" title="AI Settings">
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                <circle cx="12" cy="12" r="3"></circle>
-                <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09a1.65 1.65 0 0 0 1.51-1 1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33h.05a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51h.05a1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82v.05a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"></path>
-              </svg>
-              <span>Settings</span>
-            </button>
-            <button id="scrollDownBtn" class="action-btn icon-only" title="Scroll Down" data-target="#locatorResults">
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                <polyline points="6 9 12 15 18 9"></polyline>
-              </svg>
-            </button>
-          </div>
-        </div>
-        <div class="ai-caveat">
-          <span class="ai-caveat-text">⚠️ AI can make mistakes — verify optimized locators against the live DOM. Free-credit responses can be slow; <a href="#" id="locByokLink" class="ai-caveat-link">add your own API key</a> (BYOK) for faster results.</span>
-        </div>
-        <div id="locatorResults">
-          <div class="placeholder">
-            <svg class="placeholder-icon" width="36" height="36" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.4">
-              <circle cx="11" cy="11" r="7"></circle>
-              <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
-              <line x1="11" y1="8" x2="11" y2="14"></line>
-              <line x1="8" y1="11" x2="14" y2="11"></line>
-            </svg>
-            <p class="placeholder-line">Activate <em>Locator Mode</em>, then hover<br>any element on the page.</p>
-            <p class="placeholder-hint">Selectors are validated against the live DOM and ranked by stability.</p>
-          </div>
-        </div>
+    <!-- Settings drawer. Houses everything that used to crowd the toolbar:
+         the Auto Validate / Auto Optimize toggles, the engine + copy-format
+         selectors, and the full AI provider settings. Opened by the gear in
+         the toolbar (and by every BYOK / credits / "add key" entry point via
+         openAiSettings()). The toggles and selectors persist on change; only
+         the AI section needs an explicit Save. -->
+    <div id="settingsOverlay" class="settings-overlay" hidden></div>
+    <aside id="settingsDrawer" class="settings-drawer" aria-hidden="true" aria-label="Settings">
+      <div class="settings-drawer-header">
+        <h3>Settings</h3>
+        <button id="closeSettingsBtn" class="close-btn" aria-label="Close settings">&times;</button>
       </div>
+      <div class="settings-drawer-body">
+        <section class="settings-section">
+          <div class="settings-section-label">Locator behaviour</div>
+          <label class="settings-row">
+            <span class="settings-row-text">
+              <span class="settings-row-title">Auto&nbsp;Validate</span>
+              <span class="settings-row-sub">Check each generated locator against the live DOM as you hover.</span>
+            </span>
+            <span class="settings-toggle">
+              <input type="checkbox" id="autoValidatorToggle">
+              <span class="toggle-track" aria-hidden="true"></span>
+            </span>
+          </label>
+          <label class="settings-row">
+            <span class="settings-row-text">
+              <span class="settings-row-title">Auto&nbsp;Optimize</span>
+              <span class="settings-row-sub">Automatically run AI optimization on the selected element.</span>
+            </span>
+            <span class="settings-toggle">
+              <input type="checkbox" id="autoOptimizeToggle">
+              <span class="toggle-track" aria-hidden="true"></span>
+            </span>
+          </label>
+        </section>
 
-      <!-- Recorder view. Sibling of the locator section; toggled visible by
-           the Recorder button in the controls strip. The user keeps clicking
-           in the same browser tab next to this panel — content.js captures
-           every click and the steps + generated code update live here. -->
-      <div class="section recorder-view" id="recorderView" hidden>
-        <div class="rec-toolbar">
-          <button id="recBackBtn" class="rec-back-btn" title="Back to locator view">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <line x1="19" y1="12" x2="5" y2="12"></line>
-              <polyline points="12 19 5 12 12 5"></polyline>
-            </svg>
-            Back
-          </button>
-          <h3 class="rec-title">Intelligent Recorder</h3>
-          <span class="rec-flex-spacer"></span>
-          <span id="recStatus" class="rec-status idle">
-            <span class="rec-dot"></span>
-            <span class="rec-status-label">Idle</span>
-          </span>
-        </div>
-        <div class="rec-actions-row">
-          <button id="recStartBtn" class="rec-btn primary">Start</button>
-          <button id="recStopBtn" class="rec-btn" disabled>Stop</button>
-          <button id="recClearBtn" class="rec-btn ghost">Clear</button>
-          <label class="rec-framework-wrap">
-            <span class="rec-framework-label">Framework</span>
-            <select id="recFrameworkSelect" class="rec-framework-select">
-              <option value="selenium">Selenium</option>
+        <section class="settings-section">
+          <div class="settings-section-label">Generation engine</div>
+          <div class="form-group">
+            <label for="engineSelect">Engine</label>
+            <select id="engineSelect">
+              <option value="v2">v2 · anchor-first</option>
+              <option value="v1">v1 · legacy</option>
+            </select>
+          </div>
+          <div class="form-group">
+            <label for="copyFormatSelect">Copy as</label>
+            <select id="copyFormatSelect">
+              <option value="raw">Raw</option>
+              <option value="selenium-java">Selenium Java</option>
+              <option value="selenium-python">Selenium Python</option>
               <option value="playwright">Playwright</option>
               <option value="cypress">Cypress</option>
               <option value="webdriverio">WebdriverIO</option>
-              <option value="raw">Raw</option>
             </select>
-          </label>
-          <label class="rec-framework-wrap">
-            <span class="rec-framework-label">Language</span>
-            <select id="recLanguageSelect" class="rec-framework-select"></select>
-          </label>
-          <span class="rec-flex-spacer"></span>
-          <button id="recGenerateAiBtn" class="rec-btn ai" title="Turn the recording into a production-quality test: idiomatic code, robust locators, smart waits and assertions.">
-            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="margin-right:5px;vertical-align:-2px;">
-              <path d="M12 3l1.9 5.8a2 2 0 0 0 1.3 1.3L21 12l-5.8 1.9a2 2 0 0 0-1.3 1.3L12 21l-1.9-5.8a2 2 0 0 0-1.3-1.3L3 12l5.8-1.9a2 2 0 0 0 1.3-1.3z"></path>
-            </svg>
-            Generate with AI
-          </button>
-          <button id="recCopyCodeBtn" class="rec-btn">Copy Code</button>
-          <button id="recFeedbackBtn" class="rec-btn ghost" title="Tell us how the Recorder is working for you">
-            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="margin-right: 4px; vertical-align: -1px;">
-              <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path>
-            </svg>
-            Feedback
-          </button>
-        </div>
-        <p class="rec-subtitle">Click <strong>Start</strong>, then interact with your app in the page next to this panel — clicks, typing, selects and scrolls are all captured.</p>
-        <div class="ai-caveat">
-          <span id="recCreditsInfo" class="ai-caveat-credits" hidden></span>
-          <span class="ai-caveat-text">⚠️ AI can make mistakes — review the generated test before using it. Free-credit responses can be slow; <a href="#" id="recByokLink" class="ai-caveat-link">add your own API key</a> (BYOK) for faster results.</span>
-        </div>
-        <div class="rec-body">
-          <div class="rec-steps-pane">
-            <div class="rec-pane-title">Steps · <span id="recStepCount" class="rec-count">0</span></div>
-            <ol id="recStepsList" class="rec-steps-list"></ol>
-            <div id="recStepsEmpty" class="rec-empty">
-              <p>No steps yet — start recording and click around in your app.</p>
-            </div>
+            <p class="help-text">Wraps each locator in framework code when you copy it.</p>
           </div>
-          <div class="rec-code-pane">
-            <div class="rec-pane-title">Generated Code · <span id="recCodeFrameworkLabel" class="rec-count">raw</span><span id="recCodeAiBadge" class="rec-ai-badge" hidden>✨ AI</span><span id="recTestName" class="rec-test-name"></span></div>
-            <pre id="recCodeBlock" class="rec-code"><code id="recCodeInner">// Click "Start", then interact with the page.</code></pre>
-          </div>
-        </div>
-      </div>
-    </div>
+        </section>
 
-    <div id="copyNotification" class="copy-notification">
-      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-        <polyline points="20 6 9 17 4 12"></polyline>
-      </svg>
-      Copied to clipboard!
-    </div>
-
-    <!-- AI Settings Modal -->
-    <div id="aiSettingsModal" class="modal">
-      <div class="modal-content">
-        <div class="modal-header">
-          <h3>AI Settings</h3>
-          <button id="closeAiSettingsBtn" class="close-btn">&times;</button>
-        </div>
-        <div class="modal-body">
+        <section class="settings-section" id="settingsAiSection">
+          <div class="settings-section-label">AI provider</div>
           <div class="form-group">
-            <label for="aiProviderSelect">AI Provider</label>
+            <label for="aiProviderSelect">Provider</label>
             <select id="aiProviderSelect">
               <option value="google">Google Gemini</option>
               <option value="openrouter">OpenRouter</option>
@@ -479,12 +372,138 @@
               <input type="text" id="openRouterModel" placeholder="e.g. deepseek/deepseek-r1">
             </div>
           </div>
+
+          <button id="saveAiSettingsBtn" class="btn primary-btn settings-save-btn">Save AI Settings</button>
+        </section>
+      </div>
+    </aside>
+
+    <div class="results">
+      <div class="section locator-view" id="locatorView">
+        <div class="section-header">
+          <div class="section-title">
+            <h3 id="locatorSectionTitle">Element Locators</h3>
+            <p id="locatorSectionSubtitle" class="section-subtitle">
+              Activate locator mode and hover on the page
+            </p>
+          </div>
+          <div class="ai-caveat" id="locAiCaveat">
+            <span class="ai-caveat-text">⚠️ AI can make mistakes — verify locators. <a href="#" id="locByokLink" class="ai-caveat-link">Add your API key</a> for faster results.</span>
+          </div>
+          <div class="section-actions">
+            <button class="action-btn icon-only" title="Copy All">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+                <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+              </svg>
+            </button>
+            <button id="scrollDownBtn" class="action-btn icon-only" title="Scroll Down" data-target="#locatorResults">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <polyline points="6 9 12 15 18 9"></polyline>
+              </svg>
+            </button>
+          </div>
         </div>
-        <div class="modal-footer">
-          <button id="saveAiSettingsBtn" class="btn primary-btn">Save Settings</button>
+        <div id="locatorResults">
+          <div class="placeholder">
+            <svg class="placeholder-icon" width="36" height="36" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.4">
+              <circle cx="11" cy="11" r="7"></circle>
+              <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+              <line x1="11" y1="8" x2="11" y2="14"></line>
+              <line x1="8" y1="11" x2="14" y2="11"></line>
+            </svg>
+            <p class="placeholder-line">Activate <em>Locator Mode</em>, then hover<br>any element on the page.</p>
+            <p class="placeholder-hint">Selectors are validated against the live DOM and ranked by stability.</p>
+          </div>
+        </div>
+      </div>
+
+      <!-- Recorder view. Sibling of the locator section; toggled visible by
+           the Recorder button in the controls strip. The user keeps clicking
+           in the same browser tab next to this panel — content.js captures
+           every click and the steps + generated code update live here. -->
+      <div class="section recorder-view" id="recorderView" hidden>
+        <div class="rec-toolbar">
+          <button id="recBackBtn" class="rec-back-btn" title="Back to locator view">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <line x1="19" y1="12" x2="5" y2="12"></line>
+              <polyline points="12 19 5 12 12 5"></polyline>
+            </svg>
+            Back
+          </button>
+          <h3 class="rec-title">Intelligent Recorder</h3>
+          <span id="recCreditsInfo" class="ai-caveat-credits rec-credits" hidden></span>
+          <div class="ai-caveat" id="recAiCaveat">
+            <span class="ai-caveat-text">⚠️ AI can make mistakes — review the generated test. <a href="#" id="recByokLink" class="ai-caveat-link">Add your API key</a> for faster results.</span>
+          </div>
+          <span class="rec-flex-spacer"></span>
+          <span id="recStatus" class="rec-status idle">
+            <span class="rec-dot"></span>
+            <span class="rec-status-label">Idle</span>
+          </span>
+          <button id="recSettingsBtn" class="btn icon-btn-square" title="Settings — validation, engine, copy format & AI" aria-label="Open settings">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <circle cx="12" cy="12" r="3"></circle>
+              <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09a1.65 1.65 0 0 0 1.51-1 1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33h.05a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51h.05a1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82v.05a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"></path>
+            </svg>
+          </button>
+        </div>
+        <div class="rec-actions-row">
+          <button id="recStartBtn" class="rec-btn primary">Start</button>
+          <button id="recStopBtn" class="rec-btn" disabled>Stop</button>
+          <button id="recClearBtn" class="rec-btn ghost">Clear</button>
+          <label class="rec-framework-wrap">
+            <span class="rec-framework-label">Framework</span>
+            <select id="recFrameworkSelect" class="rec-framework-select">
+              <option value="selenium">Selenium</option>
+              <option value="playwright">Playwright</option>
+              <option value="cypress">Cypress</option>
+              <option value="webdriverio">WebdriverIO</option>
+              <option value="raw">Raw</option>
+            </select>
+          </label>
+          <label class="rec-framework-wrap">
+            <span class="rec-framework-label">Language</span>
+            <select id="recLanguageSelect" class="rec-framework-select"></select>
+          </label>
+          <span class="rec-flex-spacer"></span>
+          <button id="recGenerateAiBtn" class="rec-btn ai" title="Turn the recording into a production-quality test: idiomatic code, robust locators, smart waits and assertions.">
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="margin-right:5px;vertical-align:-2px;">
+              <path d="M12 3l1.9 5.8a2 2 0 0 0 1.3 1.3L21 12l-5.8 1.9a2 2 0 0 0-1.3 1.3L12 21l-1.9-5.8a2 2 0 0 0-1.3-1.3L3 12l5.8-1.9a2 2 0 0 0 1.3-1.3z"></path>
+            </svg>
+            Generate with AI
+          </button>
+          <button id="recCopyCodeBtn" class="rec-btn">Copy Code</button>
+          <button id="recFeedbackBtn" class="rec-btn ghost" title="Tell us how the Recorder is working for you">
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="margin-right: 4px; vertical-align: -1px;">
+              <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path>
+            </svg>
+            Feedback
+          </button>
+        </div>
+        <div class="rec-body">
+          <div class="rec-steps-pane">
+            <div class="rec-pane-title">Steps · <span id="recStepCount" class="rec-count">0</span></div>
+            <ol id="recStepsList" class="rec-steps-list"></ol>
+            <div id="recStepsEmpty" class="rec-empty">
+              <p>No steps yet — start recording and click around in your app.</p>
+            </div>
+          </div>
+          <div class="rec-code-pane">
+            <div class="rec-pane-title">Generated Code · <span id="recCodeFrameworkLabel" class="rec-count">raw</span><span id="recCodeAiBadge" class="rec-ai-badge" hidden>✨ AI</span><span id="recTestName" class="rec-test-name"></span></div>
+            <pre id="recCodeBlock" class="rec-code"><code id="recCodeInner">// Click "Start", then interact with the page.</code></pre>
+          </div>
         </div>
       </div>
     </div>
+
+    <div id="copyNotification" class="copy-notification">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+        <polyline points="20 6 9 17 4 12"></polyline>
+      </svg>
+      Copied to clipboard!
+    </div>
+
   </div>
 
   <!-- Release Notes Panel -->

--- a/devtools/panel.js
+++ b/devtools/panel.js
@@ -23,6 +23,11 @@ import {
   trackRecorderAiGenerated,
   trackRecorderAiFailed,
   trackByokCtaClicked,
+  trackSettingsOpened,
+  trackNotificationsOpened,
+  trackEngineSelected,
+  trackCopyFormatSelected,
+  trackPanelRefreshed,
 } from '../utils/analytics.js';
 import { WORKER_BASE } from '../utils/endpoints.js';
 
@@ -117,16 +122,97 @@ document.addEventListener("DOMContentLoaded", function () {
   document.body.classList.add("light-mode");
   document.body.classList.remove("dark-mode");
 
-  // Create a connection to the background page
-  const backgroundPageConnection = chrome.runtime.connect({
-    name: "panel-page",
-  });
+  // Connection to the background service worker.
+  //
+  // In MV3 the worker is torn down after ~30s idle, which silently kills this
+  // port — after which hover results never reach the panel and Refresh can't
+  // re-sync ("nothing shows up after the page sits idle"). To survive that we
+  // hold the port in a reassignable binding, keep all panel-side message
+  // handlers in a stable list (so they outlive any single port), and
+  // transparently reconnect + re-announce the tab + re-assert locator mode
+  // whenever the port drops.
+  let backgroundPageConnection = null;
+  let bgReconnectTimer = null;
+  const bgMessageHandlers = [];
 
-  // Relay the tab ID to the background page
-  backgroundPageConnection.postMessage({
-    name: "init",
-    tabId: chrome.devtools.inspectedWindow.tabId,
-  });
+  function onBackgroundMessage(handler) {
+    bgMessageHandlers.push(handler);
+  }
+
+  function postToBackground(message) {
+    try {
+      if (!backgroundPageConnection) return false;
+      backgroundPageConnection.postMessage(message);
+      return true;
+    } catch (err) {
+      // Port died between checks — drop it and let onDisconnect reconnect.
+      backgroundPageConnection = null;
+      return false;
+    }
+  }
+
+  function connectToBackground() {
+    backgroundPageConnection = chrome.runtime.connect({ name: "panel-page" });
+
+    // Single dispatcher fans out to every registered handler, so handlers
+    // survive reconnects without having to be re-bound to each new port.
+    backgroundPageConnection.onMessage.addListener((message) => {
+      for (const handler of bgMessageHandlers) {
+        try { handler(message); } catch (e) { console.error("[LocatorSpy] message handler error:", e); }
+      }
+    });
+
+    backgroundPageConnection.onDisconnect.addListener(() => {
+      backgroundPageConnection = null;
+      if (bgReconnectTimer) clearTimeout(bgReconnectTimer);
+      bgReconnectTimer = setTimeout(connectToBackground, 500);
+    });
+
+    // (Re)announce which tab this panel inspects.
+    postToBackground({
+      name: "init",
+      tabId: chrome.devtools.inspectedWindow.tabId,
+    });
+
+    // If locator mode was on before the worker died, re-assert it so hovering
+    // keeps producing locators after an idle teardown / reconnect.
+    if (isLocatorModeActive) {
+      postToBackground({
+        action: "activateLocatorMode",
+        isActive: true,
+        tabId: chrome.devtools.inspectedWindow.tabId,
+      });
+    }
+  }
+
+  connectToBackground();
+
+  // Re-sync when the inspected page navigates or is refreshed. The page's
+  // content scripts reload (losing locator mode + leaving stale results in
+  // the panel), so clear the list and — if locator mode was on — re-assert it
+  // against the freshly loaded page so hovering keeps working without a
+  // manual toggle.
+  if (chrome.devtools && chrome.devtools.network && chrome.devtools.network.onNavigated) {
+    chrome.devtools.network.onNavigated.addListener(() => {
+      locatorResults.innerHTML =
+        '<p class="placeholder">Activate locator mode and hover over elements to see locators</p>';
+      if (locatorSectionTitle && locatorSectionSubtitle) {
+        locatorSectionTitle.textContent = "Element Locators";
+        locatorSectionSubtitle.textContent = "Activate locator mode and hover on the page";
+      }
+      if (isLocatorModeActive) {
+        // Give the reloaded content scripts a moment to register, then
+        // re-activate (background re-injects as part of this message).
+        setTimeout(() => {
+          postToBackground({
+            action: "activateLocatorMode",
+            isActive: true,
+            tabId: chrome.devtools.inspectedWindow.tabId,
+          });
+        }, 300);
+      }
+    });
+  }
 
   // Toggle locator mode with animation
   locatorModeBtn.addEventListener("click", async function () {
@@ -167,7 +253,7 @@ document.addEventListener("DOMContentLoaded", function () {
     }
 
     // Send message to background script
-    backgroundPageConnection.postMessage({
+    postToBackground({
       action: "activateLocatorMode",
       isActive: isLocatorModeActive,
       tabId: chrome.devtools.inspectedWindow.tabId,
@@ -197,11 +283,34 @@ document.addEventListener("DOMContentLoaded", function () {
 
 
   // Listen for messages from the background page
-  backgroundPageConnection.onMessage.addListener(function (message) {
+  onBackgroundMessage(async function (message) {
 
 
     if (message.action === "getLocators") {
       if (window.FeedbackService) {
+        // Feedback gate: once the user has generated enough locators without
+        // submitting feedback, stop producing more on hover. Turn locator
+        // mode off in the page and surface the prompt instead of rendering
+        // new results — otherwise an already-active session keeps working
+        // past the threshold and never has to give feedback.
+        const gated = await FeedbackService.checkIfNeedsFeedback();
+        if (gated) {
+          if (isLocatorModeActive) {
+            isLocatorModeActive = false;
+            locatorModeBtn.classList.remove("active-mode");
+            locatorModeBtn.innerHTML = `
+        <img src="../images/cursor-icon.png" class="icon" width="16" height="16" alt="Locator Mode">
+        Locator Mode
+      `;
+            postToBackground({
+              action: "activateLocatorMode",
+              isActive: false,
+              tabId: chrome.devtools.inspectedWindow.tabId,
+            });
+          }
+          FeedbackService.checkFeedbackStatus();
+          return;
+        }
         FeedbackService.incrementLocatorCount();
       }
       displayLocators(message.locators, false, message.trigger);
@@ -218,7 +327,7 @@ document.addEventListener("DOMContentLoaded", function () {
   });
 
   // Add validation listener
-  backgroundPageConnection.onMessage.addListener(function (message) {
+  onBackgroundMessage(function (message) {
     if (message.action === "validationResult") {
       const btns = document.querySelectorAll(".validate-btn");
       btns.forEach((btn) => {
@@ -962,10 +1071,11 @@ test('recorded flow', async ({ page }) => {
     const interactions = state.recorderInteractions || [];
     const isActive = !!state.recorderActive;
     // Default the recorder to a runnable format rather than raw — most
-    // users come here for code, not a selector dump. The Copy-as dropdown's
-    // own default of "raw" still applies to per-locator copy.
+    // users come here for code, not a selector dump. Selenium JavaScript is
+    // the default flavor. The Copy-as dropdown's own default of "raw" still
+    // applies to per-locator copy.
     const stored = state.copyFormat;
-    const format = stored && stored !== "raw" ? stored : "selenium-java";
+    const format = stored && stored !== "raw" ? stored : "selenium-javascript";
     const decomposed = recDecomposeFormat(format);
 
     if (recFrameworkSelect && recFrameworkSelect.value !== decomposed.framework) {
@@ -1420,7 +1530,8 @@ test('recorded flow', async ({ page }) => {
   const refreshBtn = document.getElementById("refreshBtn");
 
   refreshBtn.addEventListener("click", () => {
-
+    trackPanelRefreshed();
+    logLocatorLifecycle("panel_refreshed");
 
     // Clear selected locators
     locatorResults.innerHTML =
@@ -1441,7 +1552,7 @@ test('recorded flow', async ({ page }) => {
       `;
 
       // Notify background script to deactivate locator mode
-      backgroundPageConnection.postMessage({
+      postToBackground({
         action: "activateLocatorMode",
         isActive: false,
         tabId: chrome.devtools.inspectedWindow.tabId,
@@ -1742,6 +1853,8 @@ test('recorded flow', async ({ page }) => {
     engineSelect.addEventListener("change", (event) => {
       const engine = event.target.value === "v1" ? "v1" : "v2";
       chrome.storage.local.set({ locatorEngine: engine });
+      trackEngineSelected(engine);
+      logLocatorLifecycle("locator_engine_selected", { engine });
     });
   }
 
@@ -1749,27 +1862,16 @@ test('recorded flow', async ({ page }) => {
   // Persisted in chrome.storage.local; read synchronously off the <select>.
   const copyFormatSelect = document.getElementById("copyFormatSelect");
 
-  // "What's new" banner — eligibility is purely "user is still on Raw format".
-  // No persistent dismissal: as soon as they pick any other format the banner
-  // hides, and if they ever switch back to Raw it shows again. Always-on,
-  // never closeable.
-  function syncNewFeatureBannerEligibility(format) {
-    const banner = document.getElementById("newFeatureBanner");
-    if (!banner) return;
-    const eligible = !format || format === "raw";
-    banner.classList.toggle("hidden", !eligible);
-  }
-
   if (copyFormatSelect) {
     chrome.storage.local.get("copyFormat", (result) => {
       const fmt = result.copyFormat || "raw";
       copyFormatSelect.value = fmt;
       chrome.storage.local.set({ copyFormat: fmt });
-      syncNewFeatureBannerEligibility(fmt);
     });
     copyFormatSelect.addEventListener("change", (event) => {
       chrome.storage.local.set({ copyFormat: event.target.value });
-      syncNewFeatureBannerEligibility(event.target.value);
+      trackCopyFormatSelected(event.target.value);
+      logLocatorLifecycle("copy_format_selected", { format: event.target.value });
     });
   }
 
@@ -1854,6 +1956,7 @@ test('recorded flow', async ({ page }) => {
   checkDockPosition();
   window.addEventListener("resize", checkDockPosition);
 
+
   // Scroll Down Button Logic
   const scrollDownBtn = document.getElementById("scrollDownBtn");
   if (scrollDownBtn) {
@@ -1868,10 +1971,111 @@ test('recorded flow', async ({ page }) => {
 
   // AI Optimization Feature
   const optimizeAiBtn = document.getElementById("optimizeAiBtn");
-  const aiSettingsBtn = document.getElementById("aiSettingsBtn");
-  const aiSettingsModal = document.getElementById("aiSettingsModal");
-  const closeAiSettingsBtn = document.getElementById("closeAiSettingsBtn");
   const saveAiSettingsBtn = document.getElementById("saveAiSettingsBtn");
+
+  // Settings drawer — holds the validation toggles, engine/copy selectors and
+  // the AI provider form. Opened by the toolbar gear and by openAiSettings().
+  const settingsDrawer = document.getElementById("settingsDrawer");
+  const settingsOverlay = document.getElementById("settingsOverlay");
+  const openSettingsBtn = document.getElementById("openSettingsBtn");
+  const closeSettingsBtn = document.getElementById("closeSettingsBtn");
+
+  function openSettingsDrawer(scrollToAi) {
+    if (!settingsDrawer) return;
+    settingsDrawer.classList.add("open");
+    settingsDrawer.setAttribute("aria-hidden", "false");
+    if (settingsOverlay) settingsOverlay.hidden = false;
+    document.body.classList.add("settings-open");
+    if (scrollToAi) {
+      const aiSection = document.getElementById("settingsAiSection");
+      if (aiSection) aiSection.scrollIntoView({ block: "start", behavior: "smooth" });
+    }
+  }
+
+  function closeSettingsDrawer() {
+    if (!settingsDrawer) return;
+    settingsDrawer.classList.remove("open");
+    settingsDrawer.setAttribute("aria-hidden", "true");
+    if (settingsOverlay) settingsOverlay.hidden = true;
+    document.body.classList.remove("settings-open");
+  }
+
+  if (openSettingsBtn) openSettingsBtn.addEventListener("click", () => {
+    trackSettingsOpened({ source: "toolbar" });
+    logLocatorLifecycle("settings_opened", { source: "toolbar" });
+    openSettingsDrawer(false);
+  });
+  // Recorder view hides the main toolbar (and its gear), so it carries its own
+  // settings button next to the status pill — same drawer.
+  const recSettingsBtn = document.getElementById("recSettingsBtn");
+  if (recSettingsBtn) recSettingsBtn.addEventListener("click", () => {
+    trackSettingsOpened({ source: "recorder" });
+    logLocatorLifecycle("settings_opened", { source: "recorder" });
+    openSettingsDrawer(false);
+  });
+  if (closeSettingsBtn) closeSettingsBtn.addEventListener("click", closeSettingsDrawer);
+  if (settingsOverlay) settingsOverlay.addEventListener("click", closeSettingsDrawer);
+  document.addEventListener("keydown", (e) => {
+    if (e.key === "Escape" && settingsDrawer && settingsDrawer.classList.contains("open")) {
+      closeSettingsDrawer();
+    }
+  });
+
+  // Notifications drawer — the update / AI-credit info items live here now
+  // instead of as inline banners. The existing eligibility logic still owns
+  // each item's visibility & data; we only mirror that state onto the bell
+  // badge and the empty-state line via a MutationObserver, so none of the
+  // banner logic below needs to change.
+  const notificationsBtn = document.getElementById("notificationsBtn");
+  const notificationsDrawer = document.getElementById("notificationsDrawer");
+  const notificationsOverlay = document.getElementById("notificationsOverlay");
+  const closeNotificationsBtn = document.getElementById("closeNotificationsBtn");
+  const notifBadge = document.getElementById("notifBadge");
+  const notifEmpty = document.getElementById("notifEmpty");
+  const notifItems = [
+    document.getElementById("updateAlertDev"),
+    document.getElementById("aiCreditsBanner"),
+  ].filter(Boolean);
+
+  function isNotifVisible(el) {
+    return el && !el.hidden && !el.classList.contains("hidden");
+  }
+  function refreshNotifState() {
+    const count = notifItems.filter(isNotifVisible).length;
+    if (notifBadge) notifBadge.hidden = count === 0;
+    if (notifEmpty) notifEmpty.hidden = count > 0;
+  }
+  function openNotificationsDrawer() {
+    if (!notificationsDrawer) return;
+    notificationsDrawer.classList.add("open");
+    notificationsDrawer.setAttribute("aria-hidden", "false");
+    if (notificationsOverlay) notificationsOverlay.hidden = false;
+  }
+  function closeNotificationsDrawer() {
+    if (!notificationsDrawer) return;
+    notificationsDrawer.classList.remove("open");
+    notificationsDrawer.setAttribute("aria-hidden", "true");
+    if (notificationsOverlay) notificationsOverlay.hidden = true;
+  }
+  if (notificationsBtn) notificationsBtn.addEventListener("click", () => {
+    trackNotificationsOpened({ count: notifItems.filter(isNotifVisible).length });
+    logLocatorLifecycle("notifications_opened");
+    openNotificationsDrawer();
+  });
+  if (closeNotificationsBtn) closeNotificationsBtn.addEventListener("click", closeNotificationsDrawer);
+  if (notificationsOverlay) notificationsOverlay.addEventListener("click", closeNotificationsDrawer);
+  document.addEventListener("keydown", (e) => {
+    if (e.key === "Escape" && notificationsDrawer && notificationsDrawer.classList.contains("open")) {
+      closeNotificationsDrawer();
+    }
+  });
+  if (notifItems.length) {
+    const notifObserver = new MutationObserver(refreshNotifState);
+    notifItems.forEach((el) =>
+      notifObserver.observe(el, { attributes: true, attributeFilter: ["hidden", "class"] }),
+    );
+    refreshNotifState();
+  }
   const googleApiKeyInput = document.getElementById("googleApiKey");
   const aiModelSelect = document.getElementById("aiModelSelect");
 
@@ -2248,7 +2452,7 @@ test('recorded flow', async ({ page }) => {
   refreshFreeCreditsUi();
 
   // Listen for locators message to get context
-  backgroundPageConnection.onMessage.addListener(function (message) {
+  onBackgroundMessage(function (message) {
     if (message.action === "getLocators") {
       if (message.locators) {
         currentLocators = message.locators;
@@ -2257,12 +2461,6 @@ test('recorded flow', async ({ page }) => {
         currentHtmlContext = message.htmlContext;
       }
     }
-  });
-
-  // Open Settings
-  aiSettingsBtn.addEventListener("click", () => {
-    trackAiSettingsOpened();
-    openAiSettings();
   });
 
   // Toggle Provider Fields
@@ -2300,15 +2498,10 @@ test('recorded flow', async ({ page }) => {
         openRouterModelInput.value = result.openRouterModel;
       }
 
-      aiSettingsModal.classList.add("show");
+      openSettingsDrawer(true);
       refreshFreeCreditsUi();
     });
   }
-
-  // Close Settings
-  closeAiSettingsBtn.addEventListener("click", () => {
-    aiSettingsModal.classList.remove("show");
-  });
 
   // Save Settings
   saveAiSettingsBtn.addEventListener("click", () => {
@@ -2337,7 +2530,7 @@ test('recorded flow', async ({ page }) => {
     };
 
     chrome.storage.local.set(settings, () => {
-      aiSettingsModal.classList.remove("show");
+      closeSettingsDrawer();
       showCopyNotification("Settings saved!");
       // Sync to the auth backend so the same account picks them up on
       // other devices. Fire-and-forget — local save is the source of truth.

--- a/manifest.json
+++ b/manifest.json
@@ -53,7 +53,9 @@
       "js": [
         "locator_helper.js"
       ],
-      "run_at": "document_start"
+      "run_at": "document_start",
+      "all_frames": true,
+      "match_about_blank": true
     },
     {
       "matches": [
@@ -64,7 +66,9 @@
         "locator_engine_v2.js",
         "content.js"
       ],
-      "run_at": "document_idle"
+      "run_at": "document_idle",
+      "all_frames": true,
+      "match_about_blank": true
     }
   ],
   "content_security_policy": {

--- a/utils/analytics.js
+++ b/utils/analytics.js
@@ -267,6 +267,30 @@ export function trackByokCtaClicked(meta = {}) {
   return track("byok_cta_clicked", { feature: "ai_settings", meta });
 }
 
+// Settings drawer opened (toolbar gear or recorder gear). meta.source =
+// "toolbar" | "recorder".
+export function trackSettingsOpened(meta = {}) {
+  return track("settings_opened", { feature: "settings", meta });
+}
+
+// Notifications drawer opened (header bell).
+export function trackNotificationsOpened(meta = {}) {
+  return track("notifications_opened", { feature: "notifications", meta });
+}
+
+// Locator engine switched (v1 / v2) and locator copy-format changed.
+export function trackEngineSelected(engine, meta = {}) {
+  return track("locator_engine_selected", { feature: "locator_mode", meta: { engine, ...meta } });
+}
+export function trackCopyFormatSelected(format, meta = {}) {
+  return track("copy_format_selected", { feature: "locator_mode", meta: { format, ...meta } });
+}
+
+// Panel refreshed via the Refresh button.
+export function trackPanelRefreshed(meta = {}) {
+  return track("panel_refreshed", { feature: "locator_mode", meta });
+}
+
 // ---------------------------------------------------------------------------
 // Locator Generation Lifecycle Logger
 // Only logs meaningful user actions - never on page load/refresh.


### PR DESCRIPTION
UI / layout
- Reclaim vertical space for locators: slim header, compact section header, single-line inline AI caveat, centered empty state.
- Toolbar trimmed to Locator Mode / Refresh / Recorder / Search / Optimize with AI / settings gear. Validation toggles, engine, copy format and AI provider settings moved into a slide-in settings drawer.
- Replace inline update/AI-credit banners with a header bell + notifications drawer (flat info cards, no dismiss; data updates in place via a MutationObserver that drives the bell badge).
- Recorder view: credits pill + shortened caveat moved into the header bar, subtitle trimmed, empty "No steps yet" centered, code pane given the dominant width, settings gear added next to the status pill.
- Feedback prompt is now a centered card over a blurred full-panel backdrop instead of an in-flow element.
- Hamburger menu is scrollable (was clipped on short docks).
- Selenium JavaScript is the default recorder flavor.
- Fix [hidden]-override bugs: empty credits pill and premature "AI" badge no longer render.

Bug fixes
- Iframes: content scripts now inject with all_frames + match_about_blank; background re-inject targets all frames and includes the v2 engine.
- MV3 idle teardown: panel reconnects the background port on disconnect, re-announces the tab and re-asserts locator mode; sends are null-safe.
- Re-sync on page navigation/refresh via devtools.network.onNavigated.
- Feedback gate now enforced on the hover/getLocators path, not just the toggle button, so an active session can't bypass it.

Analytics
- Emit events for previously-untracked controls: settings drawer (toolbar + recorder), notifications bell, refresh, engine select and locator copy-format select.